### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -31,6 +32,11 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+
+      - uses: flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+
       - run: go build -ldflags '-X main.version=${{ github.ref_name }}'
       - run: make -C acceptance_test
         env:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -6,13 +6,16 @@ concurrency:
   cancel-in-progress: true
 jobs:
   test:
-    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2
+    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0
     with:
       aqua_version: v2.59.1
       golangci-lint-timeout: 120s
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write
   status-check:
     runs-on: ubuntu-24.04
     if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,10 +4,12 @@ on:
     tags: [v*]
 jobs:
   release:
-    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@b2ecf54e35aca9e9689e761f5bd6d1ad9542a8cf # v8.0.0
+    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@884a4badb955df4a4ddddd802e433096371f3157 # v8.1.0
     with:
       go-version-file: go.mod
       aqua_version: v2.59.1
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
Introduce [takumi guard](https://github.com/flatt-security/setup-takumi-guard-golang) into the CI workflows.

## Changes

- `.github/workflows/release.yaml`
  - Bump `go-release-workflow` reusable workflow ref from `v8.0.0` to `v8.1.0`.
  - Add a `secrets:` block passing `TAKUMI_GUARD_BOT_ID` to the `release` job.

- `.github/workflows/go.yaml`
  - Bump `go-test-full-workflow` reusable workflow ref from `v5.0.2` to `v6.0.0`.
  - Add a `secrets:` block passing `TAKUMI_GUARD_BOT_ID` to the `test` job.
  - Add `id-token: write` to the `test` job permissions.

- `.github/workflows/acceptance-test.yaml`
  - Add the `flatt-security/setup-takumi-guard-golang@v1` setup step immediately after `actions/setup-go` and before the Go build/test steps, with `bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}`.
  - Add `id-token: write` to the `run` job permissions.

## Note

The `go-test-full-workflow` ref was bumped across a MAJOR version (`v5` -> `v6`). Please review CI for any breaking changes.

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository/organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)