### PR TITLE
fix: make the acceptance test clean up its own branches

### DIFF
--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -43,3 +43,5 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
       - run: make -C acceptance_test clean-up
         if: always()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/acceptance_test/Makefile
+++ b/acceptance_test/Makefile
@@ -1,5 +1,7 @@
 GHCP := ../ghcp
-GHCP_FLAGS := --debug -u suzuki-shunsuke -r ghcp
+OWNER := suzuki-shunsuke
+REPO := ghcp
+GHCP_FLAGS := --debug -u $(OWNER) -r $(REPO)
 
 GITHUB_RUN_NUMBER ?= 0
 BRANCH_PREFIX := ghcp-acceptance-test-$(GITHUB_RUN_NUMBER)
@@ -20,7 +22,12 @@ test:
 		--title "ghcp: acceptance-test $(BRANCH_PREFIX)" \
 		--body "ref: #$(GITHUB_PR_NUMBER)"
 
+# The workflow checks out with persist-credentials: false, so git has no
+# credentials to push with. Use the API with GITHUB_TOKEN instead.
+# Closing the pull request deletes the feature branch; the master branch is not
+# a pull request head, so it has to be deleted on its own.
 .PHONY: clean-up
 clean-up:
-	-git push origin --delete $(BRANCH_PREFIX)-master
-	-git push origin --delete $(BRANCH_PREFIX)-feature
+	-gh pr close $(BRANCH_PREFIX)-feature --repo $(OWNER)/$(REPO) --delete-branch
+	-gh api -X DELETE repos/$(OWNER)/$(REPO)/git/refs/heads/$(BRANCH_PREFIX)-master
+	-gh api -X DELETE repos/$(OWNER)/$(REPO)/git/refs/heads/$(BRANCH_PREFIX)-feature


### PR DESCRIPTION
Stops the acceptance test from leaving branches behind.

## Problem

Every run left its two test branches in the repository, and later runs collided with them:

```
Error: could not commit the files: could not update the existing branch (ghcp-acceptance-test-391-master):
GitHub API error: Refusing to perform non-fast-foward update when `force=false`.
```

40 leftover `ghcp-acceptance-test-*` branches had accumulated, plus the pull requests each run opened. I deleted them, so CI is unblocked now, but it would come straight back without this change.

## Cause

The `clean-up` step ran `git push origin --delete`, but the job checks out with `persist-credentials: false` and the step was given no token. git had no credentials:

```
fatal: could not read Username for 'https://github.com'
```

The step is `if: always()`, so this failed silently on every run.

## Change

Delete through the API with `GITHUB_TOKEN` instead of pushing with git, which keeps `persist-credentials: false` intact.

Closing the pull request takes the feature branch with it and stops the acceptance test pull requests from accumulating too. The master branch is not a pull request head, so it is deleted on its own. The feature branch also gets a direct delete, to cover runs that fail before the pull request is created - which is exactly how the current backlog built up.

All three commands keep the leading `-` so clean-up stays best-effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)