### PR TITLE
fix: update the branch when creating it conflicts

### DIFF
--- a/pkg/usecases/commit/commit.go
+++ b/pkg/usecases/commit/commit.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/wire"
 
@@ -111,7 +112,42 @@ func (u *Commit) Do(ctx context.Context, in Input) error {
 		return nil
 	}
 	if err := u.createNewBranch(ctx, in, files, q); err != nil {
-		return fmt.Errorf("could not create a branch (%s) based on the default branch: %w", in.TargetBranchName, err)
+		if !isRefAlreadyExists(err) {
+			return fmt.Errorf("could not create a branch (%s) based on the default branch: %w", in.TargetBranchName, err)
+		}
+		// QueryForCommit reported the branch as missing, but creating it was
+		// rejected because it does exist. The query is eventually consistent, so
+		// a branch created moments ago is not always visible yet. Look it up
+		// again and update it instead.
+		u.Logger.Infof("The branch (%s) already exists, updating it instead", in.TargetBranchName)
+		if err := u.updateBranchAfterCreateConflict(ctx, in, files); err != nil {
+			return fmt.Errorf("could not create a branch (%s) based on the default branch: %w", in.TargetBranchName, err)
+		}
+	}
+	return nil
+}
+
+// isRefAlreadyExists reports whether the error is GitHub rejecting createRef
+// because the ref is already there.
+func isRefAlreadyExists(err error) bool {
+	return strings.Contains(err.Error(), "already exists")
+}
+
+func (u *Commit) updateBranchAfterCreateConflict(ctx context.Context, in Input, files []fs.File) error {
+	q, err := u.GitHub.QueryForCommit(ctx, github.QueryForCommitInput{
+		ParentRepository: in.ParentRepository,
+		ParentRef:        in.CommitStrategy.RebaseUpstream(), // valid only if rebase
+		TargetRepository: in.TargetRepository,
+		TargetBranchName: in.TargetBranchName,
+	})
+	if err != nil {
+		return fmt.Errorf("could not find the repository: %w", err)
+	}
+	if !q.TargetBranchExists() {
+		return errors.New("the branch was reported as already existing but it cannot be found")
+	}
+	if err := u.updateExistingBranch(ctx, in, files, q); err != nil {
+		return fmt.Errorf("could not update the existing branch: %w", err)
 	}
 	return nil
 }

--- a/pkg/usecases/commit/commit_test.go
+++ b/pkg/usecases/commit/commit_test.go
@@ -2,6 +2,7 @@ package commit
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -408,6 +409,96 @@ func TestCommitToBranch_Do(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			run(t, c)
 		})
+	}
+}
+
+func TestCommitToBranch_Do_branchAppearsWhileCreating(t *testing.T) {
+	ctx := context.TODO()
+	in := Input{
+		TargetRepository: targetRepositoryID,
+		TargetBranchName: "topic",
+		ParentRepository: parentRepositoryID,
+		CommitStrategy:   commitstrategy.FastForward,
+		CommitMessage:    "message",
+		Paths:            []string{"path"},
+	}
+	queryInput := github.QueryForCommitInput{
+		ParentRepository: parentRepositoryID,
+		TargetRepository: targetRepositoryID,
+		TargetBranchName: "topic",
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	gitHub := mock_github.NewMockInterface(ctrl)
+	gomock.InOrder(
+		// The query does not see the branch yet.
+		gitHub.EXPECT().
+			QueryForCommit(ctx, queryInput).
+			Return(&github.QueryForCommitOutput{
+				CurrentUserName:              "current",
+				ParentDefaultBranchCommitSHA: "masterCommitSHA",
+				ParentDefaultBranchTreeSHA:   "masterTreeSHA",
+				TargetRepositoryNodeID:       targetRepositoryNodeID,
+			}, nil),
+		// But it is there, so creating it is rejected.
+		gitHub.EXPECT().
+			CreateBranch(ctx, github.CreateBranchInput{
+				RepositoryNodeID: targetRepositoryNodeID,
+				BranchName:       "topic",
+				CommitSHA:        "commitSHA",
+			}).
+			Return(errors.New(`GitHub API error: A ref named "refs/heads/topic" already exists in the repository.`)),
+		// The second query sees it.
+		gitHub.EXPECT().
+			QueryForCommit(ctx, queryInput).
+			Return(&github.QueryForCommitOutput{
+				CurrentUserName:              "current",
+				ParentDefaultBranchCommitSHA: "masterCommitSHA",
+				ParentDefaultBranchTreeSHA:   "masterTreeSHA",
+				TargetBranchNodeID:           targetBranchNodeID,
+				TargetBranchCommitSHA:        "topicCommitSHA",
+				TargetBranchTreeSHA:          "topicTreeSHA",
+			}, nil),
+		gitHub.EXPECT().
+			UpdateBranch(ctx, github.UpdateBranchInput{
+				BranchRefNodeID: targetBranchNodeID,
+				CommitSHA:       "commitSHA",
+			}).
+			Return(nil),
+	)
+
+	createGitObject := mock_gitobject.NewMockInterface(ctrl)
+	for _, parent := range []struct {
+		commitSHA git.CommitSHA
+		treeSHA   git.TreeSHA
+	}{
+		{"masterCommitSHA", "masterTreeSHA"},
+		{"topicCommitSHA", "topicTreeSHA"},
+	} {
+		createGitObject.EXPECT().
+			Do(ctx, gitobject.Input{
+				Files:           theFiles,
+				Repository:      targetRepositoryID,
+				CommitMessage:   "message",
+				ParentCommitSHA: parent.commitSHA,
+				ParentTreeSHA:   parent.treeSHA,
+			}).
+			Return(&gitobject.Output{
+				CommitSHA:    "commitSHA",
+				ChangedFiles: 1,
+			}, nil)
+	}
+
+	useCase := Commit{
+		CreateGitObject: createGitObject,
+		FileSystem:      newFileSystemMock(ctrl),
+		Logger:          testingLogger.New(t),
+		GitHub:          gitHub,
+	}
+	if err := useCase.Do(ctx, in); err != nil {
+		t.Errorf("err wants nil but %+v", err)
 	}
 }
 


### PR DESCRIPTION
Makes consecutive commits to the same branch reliable, and with it the acceptance test.

## Problem

The acceptance test intermittently fails on the third `ghcp commit`, which targets a branch the second one just created:

```
could not create a branch (ghcp-acceptance-test-402-feature) based on the default branch:
error while creating ghcp-acceptance-test-402-feature branch: GitHub API error:
A ref named "refs/heads/ghcp-acceptance-test-402-feature" already exists in the repository.
```

`run#395` through `#399` and `#402` failed this way; `#400`, `#401` and a rerun of `#402` passed. It is not limited to the test - any caller committing twice in a row to the same branch can hit it.

## Cause

`QueryForCommit` goes through the GraphQL API, which is eventually consistent. A branch created moments earlier is not always visible to it, so `TargetBranchExists()` returns false and ghcp takes the create path. `createRef` then hits the branch that does exist and fails.

## Change

When `createRef` is rejected because the ref already exists, query the branch again and update it instead of failing. That is what the caller asked for either way, and it also covers the branch being created by another process in between.

If the second query still cannot find the branch, the error is returned rather than retried, so a genuine failure is not hidden.

Added `TestCommitToBranch_Do_branchAppearsWhileCreating`, which drives the whole path: query misses, create is rejected, second query hits, branch is updated.

`go build`, `go test ./...` and `go vet ./...` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)