### PR TITLE
fix: don't create an orphan commit when the parent ref is not found

### DIFF
--- a/pkg/github/branch.go
+++ b/pkg/github/branch.go
@@ -3,7 +3,9 @@ package github
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/cenkalti/backoff/v7"
 	"github.com/shurcooL/githubv4"
 	"github.com/suzuki-shunsuke/ghcp/pkg/git"
 )
@@ -31,8 +33,48 @@ func (q *QueryForCommitOutput) TargetBranchExists() bool {
 	return q.TargetBranchCommitSHA != ""
 }
 
+// parentRefMaxElapsedTime is the maximum time to wait for the parent ref to become available.
+const parentRefMaxElapsedTime = 30 * time.Second
+
 // QueryForCommit returns the repository for creating or updating the branch.
+// If the parent ref is given, it must exist.
+// The GraphQL API is eventually consistent and a ref created moments ago is not
+// always visible yet, so this waits for the ref if it is not found.
 func (c *GitHub) QueryForCommit(ctx context.Context, in QueryForCommitInput) (*QueryForCommitOutput, error) {
+	out, err := c.queryForCommit(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	if in.ParentRef == "" || out.ParentRefCommitSHA != "" {
+		return out, nil
+	}
+	return c.waitUntilParentRefIsAvailable(ctx, in)
+}
+
+// waitUntilParentRefIsAvailable queries the repository until the parent ref is available.
+// Without this, ghcp would create a commit which has no parent silently.
+func (c *GitHub) waitUntilParentRefIsAvailable(ctx context.Context, in QueryForCommitInput) (*QueryForCommitOutput, error) {
+	c.Logger.Debugf("The parent ref (%s) is not found. Waiting for the ref", in.ParentRef)
+	operation := func() (*QueryForCommitOutput, error) {
+		out, err := c.queryForCommit(ctx, in)
+		if err != nil {
+			return nil, backoff.Permanent(err)
+		}
+		if out.ParentRefCommitSHA == "" {
+			return nil, fmt.Errorf("the parent ref (%s) is not found in the repository (%s)", in.ParentRef, in.ParentRepository)
+		}
+		return out, nil
+	}
+	out, err := backoff.Retry(ctx, operation,
+		backoff.WithBackOff(backoff.NewExponentialBackOff()),
+		backoff.WithMaxElapsedTime(parentRefMaxElapsedTime))
+	if err != nil {
+		return nil, fmt.Errorf("retry over: %w", err)
+	}
+	return out, nil
+}
+
+func (c *GitHub) queryForCommit(ctx context.Context, in QueryForCommitInput) (*QueryForCommitOutput, error) {
 	var q struct {
 		Viewer struct {
 			Login string

--- a/pkg/usecases/commit/commit.go
+++ b/pkg/usecases/commit/commit.go
@@ -133,6 +133,17 @@ func (f *pathFilter) ExcludeFile(string) bool {
 	return false
 }
 
+// validateParentRef returns an error if the parent ref was not found.
+// The user explicitly gave the ref, so an empty SHA is never a valid result.
+// Committing with an empty SHA would silently create a commit which has no
+// parent, so the branch would share no history with the given ref.
+func validateParentRef(in Input, q *github.QueryForCommitOutput) error {
+	if q.ParentRefCommitSHA != "" {
+		return nil
+	}
+	return fmt.Errorf("the parent ref (%s) is not found in the repository (%s), it may not exist or may not be visible yet", in.CommitStrategy.RebaseUpstream(), in.ParentRepository)
+}
+
 func (u *Commit) createNewBranch(ctx context.Context, in Input, files []fs.File, q *github.QueryForCommitOutput) error {
 	gitObj := gitobject.Input{
 		Files:         files,
@@ -150,6 +161,9 @@ func (u *Commit) createNewBranch(ctx context.Context, in Input, files []fs.File,
 		gitObj.ParentTreeSHA = q.ParentDefaultBranchTreeSHA
 	case in.CommitStrategy.IsRebase():
 		u.Logger.Infof("Creating a branch (%s) based on the ref (%s)", in.TargetBranchName, in.CommitStrategy.RebaseUpstream())
+		if err := validateParentRef(in, q); err != nil {
+			return err
+		}
 		gitObj.ParentCommitSHA = q.ParentRefCommitSHA
 		gitObj.ParentTreeSHA = q.ParentRefTreeSHA
 	case in.CommitStrategy.NoParent():
@@ -203,6 +217,9 @@ func (u *Commit) updateExistingBranch(ctx context.Context, in Input, files []fs.
 		gitObj.ParentTreeSHA = q.TargetBranchTreeSHA
 	case in.CommitStrategy.IsRebase():
 		u.Logger.Infof("Rebasing the branch (%s) on the ref (%s)", in.TargetBranchName, in.CommitStrategy.RebaseUpstream())
+		if err := validateParentRef(in, q); err != nil {
+			return err
+		}
 		gitObj.ParentCommitSHA = q.ParentRefCommitSHA
 		gitObj.ParentTreeSHA = q.ParentRefTreeSHA
 	case in.CommitStrategy.NoParent():

--- a/pkg/usecases/commit/commit_test.go
+++ b/pkg/usecases/commit/commit_test.go
@@ -2,6 +2,7 @@ package commit
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -407,6 +408,67 @@ func TestCommitToBranch_Do(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			run(t, c)
+		})
+	}
+}
+
+func TestCommitToBranch_Do_parentRefNotFound(t *testing.T) {
+	ctx := context.TODO()
+	in := Input{
+		TargetRepository: targetRepositoryID,
+		TargetBranchName: "topic",
+		ParentRepository: parentRepositoryID,
+		CommitStrategy:   commitstrategy.RebaseOn("develop"),
+		CommitMessage:    "message",
+		Paths:            []string{"path"},
+	}
+	queryInput := github.QueryForCommitInput{
+		ParentRepository: parentRepositoryID,
+		ParentRef:        "develop",
+		TargetRepository: targetRepositoryID,
+		TargetBranchName: "topic",
+	}
+
+	// The query returns an empty parent ref if the ref does not exist,
+	// or if it is not visible yet due to the eventual consistency of the API.
+	// ghcp must not create a commit which has no parent in this case.
+	for name, q := range map[string]*github.QueryForCommitOutput{
+		"when the branch does not exist, it should not create it": {
+			CurrentUserName:              "current",
+			ParentDefaultBranchCommitSHA: "masterCommitSHA",
+			ParentDefaultBranchTreeSHA:   "masterTreeSHA",
+			TargetRepositoryNodeID:       targetRepositoryNodeID,
+		},
+		"when the branch exists, it should not update it": {
+			CurrentUserName:              "current",
+			ParentDefaultBranchCommitSHA: "masterCommitSHA",
+			ParentDefaultBranchTreeSHA:   "masterTreeSHA",
+			TargetBranchNodeID:           targetBranchNodeID,
+			TargetBranchCommitSHA:        "topicCommitSHA",
+			TargetBranchTreeSHA:          "topicTreeSHA",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			gitHub := mock_github.NewMockInterface(ctrl)
+			gitHub.EXPECT().
+				QueryForCommit(ctx, queryInput).
+				Return(q, nil)
+
+			useCase := Commit{
+				CreateGitObject: mock_gitobject.NewMockInterface(ctrl),
+				FileSystem:      newFileSystemMock(ctrl),
+				Logger:          testingLogger.New(t),
+				GitHub:          gitHub,
+			}
+			err := useCase.Do(ctx, in)
+			if err == nil {
+				t.Fatal("err wants non-nil but nil")
+			}
+			if !strings.Contains(err.Error(), "develop") {
+				t.Errorf("err wants to contain the parent ref name but %+v", err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Problem

The acceptance test failed with an error that pointed nowhere near the actual cause:

```
could not create a pull request: GitHub API error: The ghcp-acceptance-test-403-feature branch has no history in common with ghcp-acceptance-test-403-master
```

https://github.com/suzuki-shunsuke/ghcp/actions/runs/30198183266/job/89783398201

The debug log shows what really happened. The master branch was created, and 5 ms later the query for it as a parent ref came back empty:

```
10:24:06.446  INFO  Created a branch (ghcp-acceptance-test-403-master)
10:24:06.451  DEBUG Querying the repository with map[... parentRef:ghcp-acceptance-test-403-master ...]
10:24:06.671  DEBUG Got the result: {... ParentRef:{Target:{Commit:{Oid: Tree:{Oid:}}}} ...}
10:24:06.671  INFO  Creating a branch (ghcp-acceptance-test-403-feature) based on the ref (ghcp-acceptance-test-403-master)
10:24:06.812  DEBUG Creating a tree {... BaseTreeSHA: Files:[{Filename:fixture2.txt ...}]}
10:24:06.951  DEBUG Creating a commit {... ParentCommitSHA: TreeSHA:0daeded6...}
```

The GraphQL API is eventually consistent, so a ref created moments ago is not always visible yet. `QueryForCommitOutput.ParentRefCommitSHA` is documented as empty when the parent ref does not exist, but the rebase case assigned it unconditionally. With an empty SHA, ghcp created an orphan root commit and reported success. Three steps later the pull request creation failed, far from the code that caused it.

## Fix

Two layers.

`pkg/usecases/commit/commit.go` returns an error when the parent ref is not found. The user explicitly gave the ref, so an empty SHA is never a valid result. Both rebase sites are covered: `createNewBranch` is the path that failed in CI, and `updateExistingBranch` had the same hole.

`pkg/github/branch.go` handles the replication lag itself. `QueryForCommit` keeps the happy path untouched, and only when a parent ref was given but came back empty does it re-query under backoff for up to 30 seconds. This mirrors `waitUntilGitDataIsAvailable` in `pkg/github/fork.go`, which already uses `cenkalti/backoff/v7`, so there is no new dependency and no new abstraction.

Splitting it this way keeps the use-case unit tests instant while still fixing the flake at its source. A ref that exists but is not replicated yet now resolves within 30 seconds instead of producing an orphan commit. A ref that genuinely does not exist fails with a message naming it.

## Trade-off

A mistyped ref name now takes up to 30 seconds to report the error. `parentRefMaxElapsedTime` is a constant, not a flag.

## Tests

`TestCommitToBranch_Do_parentRefNotFound` covers both the create-branch and update-branch cases. `CreateGitObject` is a bare mock with no `EXPECT()`, so the test also fails if ghcp ever tries to build a commit from an empty parent.

`go build ./...`, `go test ./...` and `golangci-lint run` all pass.

## Relation to #1379

Independent. #1379 handles a different manifestation of the same eventual-consistency class, where `createRef` is rejected with "already exists". This branch is based on `main`, not on #1379, and the two touch adjacent but non-overlapping code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
